### PR TITLE
SDK 3.8 Update + QoL Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,11 @@ Most of the parameters follow the same name as the C++ API. Except that `_` is r
  * `depth-maximum-distance`: Maximum depth value
  * `depth-mode`: Depth Mode - {NONE (0), PERFORMANCE (1), QUALITY (2), ULTRA (3)}
  * `coordinate-system`: 3D Coordinate System - {Image (0) - Left handed, Y up (1) - Right handed, Y up (2) - Right handed, Z up (3) - Left handed, Z up (4) - Right handed, Z up, X fwd (5)}
- * `camera-disable-self-calib`: Disable the self calibration processing when the camera is opened - {TRUE, FALSE}
+ * `roi`: Enable region of interest for SDK to focus on - {TRUE, FALSE}
+ * `roi-x`: Region of interest focus left 'X' coordinate (-1 to not set ROI) - {-1,2208}
+ * `roi-y`: Region of interest focus left 'Y' coordinate (-1 to not set ROI) - {-1,1242}
+ * `roi-w`: Region of interest focus height (-1 to not set ROI) - {-1,2208}
+ * `roi-h`: Region of interest focus height (-1 to not set ROI) - {-1,1242}
  * `depth-stabilization`: Enable depth stabilization - {TRUE, FALSE}
  * `confidence-threshold`: Specify the Depth Confidence Threshold - [0,100]
  * `texture-confidence-threshold`: Specify the Texture Confidence Threshold - [0,100]
@@ -148,6 +152,8 @@ Most of the parameters follow the same name as the C++ API. Except that `_` is r
  * `enable-imu-fusion`: This setting allows you to enable or disable IMU fusion. When set to false, only the optical odometry will be used - {TRUE, FALSE}
  * `enable-pose-smoothing`: This mode enables smooth pose correction for small drift correction - {TRUE, FALSE}
  * `set-floor-as-origin`: This mode initializes the tracking to be aligned with the floor plane to better position the camera in space.
+ * `set-gravity-as-origin`: This mode initializes the tracking to override 2 of the 3 rotations from initial-world-transform using IMU gravity default: true - {TRUE, FALSE}
+ * `pos-depth-min-range`: Sets the minimum depth used by the SDK for positional tracking (-1 for no minimum depth) - {-1, 65535} 
  * `initial-world-transform-x`: X position of the camera in the world frame when the camera is started.
  * `initial-world-transform-y`: Y position of the camera in the world frame when the camera is started.
  * `initial-world-transform-z`: Z position of the camera in the world frame when the camera is started.
@@ -161,6 +167,8 @@ Most of the parameters follow the same name as the C++ API. Except that `_` is r
  * `od-confidence`: Minimum Detection Confidence - {0,100}
  * `od-max-range`: Maximum Detection Range - [-1,20000]
  * `od-body-fitting`: Set to TRUE to enable body fitting for skeleton tracking - {TRUE, FALSE}
+ * `od-prediction-timeout-s`: Timeout when an object is not detected anymore for the SDK to predict its position for a short period before its state switched to SEARCHING (sec)
+ * `od-allow-reduced-precision-inference`: Runs inference at a lower precision to improve runtime and memory usage - {TRUE, FALSE} 
  * `brightness`: Image brightness - {0,8}
  * `contrast`: Image contrast - {0,8}
  * `hue`: Image hue - {0,11}

--- a/gst-zed-data-mux/gstzeddatamux.cpp
+++ b/gst-zed-data-mux/gstzeddatamux.cpp
@@ -466,7 +466,7 @@ static GstFlowReturn gst_zeddatamux_chain_data(GstPad* pad, GstObject * parent, 
                     gst_buffer_add_zed_src_meta( out_buf,
                                                  meta->info,
                                                  meta->pose, meta->sens,
-                                                 meta->od_enabled, meta->obj_count, meta->objects);
+                                                 meta->od_enabled, meta->obj_count, meta->objects, meta->frame_id);
 
                     // ----> Timestamp meta-data
                     GST_TRACE ("Out buffer set timestamp" );
@@ -621,7 +621,7 @@ static GstFlowReturn gst_zeddatamux_chain_video(GstPad* pad, GstObject * parent,
                     gst_buffer_add_zed_src_meta( out_buf,
                                                  meta->info,
                                                  meta->pose, meta->sens,
-                                                 meta->od_enabled, meta->obj_count, meta->objects);
+                                                 meta->od_enabled, meta->obj_count, meta->objects, meta->frame_id);
 
                     // ----> Timestamp meta-data
                     GST_TRACE ("Out buffer set timestamp" );

--- a/gst-zed-demux/gstzeddemux.cpp
+++ b/gst-zed-demux/gstzeddemux.cpp
@@ -560,7 +560,8 @@ static GstFlowReturn gst_zeddemux_chain(GstPad* pad, GstObject * parent, GstBuff
                                              meta->sens,
                                              meta->od_enabled,
                                              meta->obj_count,
-                                             meta->objects );
+                                             meta->objects,
+                                             meta->frame_id );
             }
 
             GST_TRACE ("Left buffer set timestamp" );
@@ -651,7 +652,8 @@ static GstFlowReturn gst_zeddemux_chain(GstPad* pad, GstObject * parent, GstBuff
                                              meta->sens,
                                              meta->od_enabled,
                                              meta->obj_count,
-                                             meta->objects );
+                                             meta->objects,
+                                             meta->frame_id );
             }
 
             GST_TRACE ("Aux buffer set timestamp" );

--- a/gst-zed-meta/gstzedmeta.cpp
+++ b/gst-zed-meta/gstzedmeta.cpp
@@ -123,7 +123,8 @@ static gboolean gst_zed_src_meta_transform( GstBuffer* transbuf, GstMeta * meta,
                                  emeta->sens,
                                  emeta->od_enabled,
                                  emeta->obj_count,
-                                 emeta->objects );
+                                 emeta->objects, 
+                                 emeta->frame_id);
 
 
     return TRUE;
@@ -162,7 +163,8 @@ GstZedSrcMeta* gst_buffer_add_zed_src_meta( GstBuffer* buffer,
                                             ZedSensors& sens,
                                             gboolean od_enabled,
                                             guint8 obj_count,
-                                            ZedObjectData* objects)
+                                            ZedObjectData* objects,
+                                            guint64 frame_id)
 {
     GST_TRACE( "gst_buffer_add_zed_src_meta" );
 
@@ -182,6 +184,8 @@ GstZedSrcMeta* gst_buffer_add_zed_src_meta( GstBuffer* buffer,
     meta->obj_count = obj_count;
 
     memcpy( &meta->objects, objects, obj_count*sizeof(ZedObjectData));
+
+    meta->frame_id = frame_id;
 
     return meta;
 }

--- a/gst-zed-meta/gstzedmeta.h
+++ b/gst-zed-meta/gstzedmeta.h
@@ -184,6 +184,7 @@ struct _GstZedSrcMeta {
 
     gboolean od_enabled;
     guint8 obj_count;
+    guint64 frame_id;
     ZedObjectData objects[256];
 };
 
@@ -258,7 +259,8 @@ GstZedSrcMeta* gst_buffer_add_zed_src_meta( GstBuffer* buffer,
                                             ZedSensors& sens,
                                             gboolean od_enabled,
                                             guint8 obj_count,
-                                            ZedObjectData* objects);
+                                            ZedObjectData* objects,
+                                            guint64 frame_id);
 
 G_END_DECLS
 

--- a/gst-zed-src/gstzedsrc.cpp
+++ b/gst-zed-src/gstzedsrc.cpp
@@ -2313,14 +2313,15 @@ static GstFlowReturn gst_zedsrc_fill( GstPushSrc * psrc, GstBuffer * buf )
     }
     // <---- Object detection metadata
 
-    gst_buffer_add_zed_src_meta( buf, info, pose, sens, src->object_detection, obj_count, obj_data);
-
     // ----> Timestamp meta-data
     GST_BUFFER_TIMESTAMP(buf) = GST_CLOCK_DIFF (gst_element_get_base_time (GST_ELEMENT (src)),
                                                 clock_time);
     GST_BUFFER_DTS(buf) = GST_BUFFER_TIMESTAMP(buf);
     GST_BUFFER_OFFSET(buf) = temp_ugly_buf_index++;
     // <---- Timestamp meta-data
+
+    guint64 offset = GST_BUFFER_OFFSET(buf);
+    GstZedSrcMeta* meta = gst_buffer_add_zed_src_meta( buf, info, pose, sens, src->object_detection, obj_count, obj_data, offset);
 
     // Buffer release
     gst_buffer_unmap( buf, &minfo );

--- a/gst-zed-src/gstzedsrc.h
+++ b/gst-zed-src/gstzedsrc.h
@@ -64,6 +64,11 @@ struct _GstZedSrc
     gboolean camera_disable_self_calib;
     gboolean depth_stabilization;
     gint coord_sys;
+    gboolean roi;
+    gint roi_x;
+    gint roi_y;
+    gint roi_w;
+    gint roi_h;
     //gboolean enable_right_side_measure;
 
     gint confidence_threshold;
@@ -78,6 +83,8 @@ struct _GstZedSrc
     gboolean enable_imu_fusion;
     gboolean enable_pose_smoothing;
     gboolean set_floor_as_origin;
+    gboolean set_gravity_as_origin;
+    gfloat depth_min_range;
     gfloat init_pose_x;
     gfloat init_pose_y;
     gfloat init_pose_z;
@@ -93,6 +100,8 @@ struct _GstZedSrc
     gfloat od_det_conf;
     gfloat od_max_range;
     gboolean od_body_fitting;
+    gfloat od_prediction_timeout_s;
+    gboolean od_allow_reduced_precision_inference;
 
     gint brightness;
     gint contrast;


### PR DESCRIPTION
Updates the plugin to add the new features from the the ZED SDK v3.8 release, namely:

1. Adds `Camera::setRegionOfInterest` function as the `zedsrc` properties `roi`, `roi-x`, `roi-y`, `roi-w`, and `roi-h`
2. Adds `ObjectDetectionParameters::allow_reduced_precision_inference` as the `zedsrc` property `od-allow-reduced-precision-inference`
3. Adds `PositionalTrackingParameter::set_floor_as_origin` as the `zedsrc` property `set-gravity-as-origin`
4. Adds `PositionalTrackingParameters::depth_min_range` as the `zedsrc` property `pos-depth-min-range`
5. Adds ObjectDetectionParaeters::prediction_timeout_s` as the `zedsrc` property `od-prediction-timeout-s`

Adds a `frame_id` field to `GstZedSrcMeta` in order to track the meta/buffer throughout the GStreamer pipeline (when working with source code).

Fixes a bug in the initial world transform that input roll, pitch, yaw in the same order regardless of the coordinate system being used

Notes:
1. I copied the descriptions for the new `zedsrc` parameters from the API reference but some of them may still not be the best
2. Our implementation of `frame_id` could probably be improved and welcome any redesign of it, but we find it necessary for our code to have the ability to track buffers throughout the pipeline. We work with NVidia Deepstream via CPP and found that some of Nvidia's GStreamer elements "mess-up" the information in the base GstBuffer which prevents us from using that to track the Buffer throughout the pipeline
3. We may have missed some edge cases if any of the new parameters are mutually exclusive with other ones
