### PR TITLE
Bugfix for checking valid roi parameters

### DIFF
--- a/gst-zed-src/gstzedsrc.cpp
+++ b/gst-zed-src/gstzedsrc.cpp
@@ -1904,9 +1904,9 @@ static gboolean gst_zedsrc_start( GstBaseSrc * bsrc )
 	    int roi_x_end = src->roi_x + src->roi_w;
 	    int roi_y_end = src->roi_y + src->roi_h;
 	    sl::Resolution resolution = sl::getResolution(init_params.camera_resolution);
-	    if (src->roi_x < 0 || src->roi_x >= resolution.width ||
-		    src->roi_y < 0 || src->roi_y >= resolution.height ||
-		    roi_x_end >= resolution.width || roi_y_end >= resolution.height) {
+	    if (src->roi_x >= 0 && src->roi_x < resolution.width &&
+		    src->roi_y >= 0 && src->roi_y < resolution.height &&
+		    roi_x_end <= resolution.width && roi_y_end <= resolution.height) {
 
 		sl::uchar1 uint0 = 0;
 		sl::uchar1 uint1 = 1;


### PR DESCRIPTION
Realized I made a mistake in my previous PR that the parameters for `setRegionOfInterest` were checked if they were invalid, and if so, then create the ROI. This PR fixes it so when all roi parameters (`roi-x, roi-y, roi-w, roi-h`) are valid, the ROI is assigned. (Turns out, my use case at the time was an edge case so that's how I did not find this)

Verified changes by the following test cases for `roi=1` and `camera-resolution=1` (1080p):

- `roi-x=0`, `roi-y=0`, `roi-w=1920`, `roi-h=1080` -> PASS
- `roi-x=-1`, `roi-y=0`, `roi-w=1920`, `roi-h=1080` -> FAIL
- `roi-x=0`, `roi-y=-1`, `roi-w=1920`, `roi-h=1080` -> FAIL
- `roi-x=0`, `roi-y=0`, `roi-w=1921`, `roi-h=1080` -> FAIL
- `roi-x=0`, `roi-y=0`, `roi-w=1920`, `roi-h=1081` -> FAIL
- `roi-x=1080`, `roi-y=0`, `roi-w=1`, `roi-h=1` -> FAIL
- `roi-x=0`, `roi-y=1920`, `roi-w=1`, `roi-h=1` -> FAIL