### PR TITLE
Exposure and Gain ROI Runtime Control & Bugfix for valid ROI checks

### DIFF
--- a/gst-zed-src/gstzedsrc.cpp
+++ b/gst-zed-src/gstzedsrc.cpp
@@ -2626,6 +2626,23 @@ static GstFlowReturn gst_zedsrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
         static_cast<sl::REFERENCE_FRAME>(src->measure3D_reference_frame);
     zedRtParams.enable_fill_mode = src->fill_mode;
     zedRtParams.remove_saturated_areas = true;
+
+    if( src->aec_agc==TRUE ) {
+    	if ( src->aec_agc_roi_x!=-1 &&
+		src->aec_agc_roi_y!=-1 &&
+		src->aec_agc_roi_w!=-1 &&
+		src->aec_agc_roi_h!=-1) {
+		sl::Rect roi;
+		roi.x=src->aec_agc_roi_x;
+		roi.y=src->aec_agc_roi_y;
+		roi.width=src->aec_agc_roi_w;
+		roi.height=src->aec_agc_roi_h;
+		sl::SIDE side = static_cast<sl::SIDE>(src->aec_agc_roi_side);
+		GST_INFO(" Runtime AEC_AGC_ROI: (%d,%d)-%dx%d - Side: %d",
+			roi.x, roi.y, roi.width, roi.height, side);
+		src->zed.setCameraSettings( sl::VIDEO_SETTINGS::AEC_AGC_ROI, roi, side );
+	}
+    }
     // <---- Set runtime parameters
 
     // ----> ZED grab

--- a/gst-zed-src/gstzedsrc.h
+++ b/gst-zed-src/gstzedsrc.h
@@ -145,6 +145,7 @@ struct _GstZedSrc {
     gint aec_agc_roi_w;
     gint aec_agc_roi_h;
     gint aec_agc_roi_side;
+    gboolean exposure_gain_updated;
     gint whitebalance_temperature;
     gboolean whitebalance_temperature_auto;
     gboolean led_status;


### PR DESCRIPTION
Adds runtime control for auto exposure & gain Region of Interest (ROI) and manual (Exposure & gain values) by setting `ZedSrc` properties while the pipeline is active. Only available for source code implementations; not available from the command line. Uses a flag (`exposure_gain_updated`) to only update whenever a property has been changed (small optimization). This feature pairs well with object detection pipelines where a finer exposure control dependent on the object location in the image is desired.

Fixes a bug in ROI validation checks where only an invalid ROI (e.g. not set or exceeds bounds of image) was accepted. 

_Note: This is an update to the previous PR https://github.com/stereolabs/zed-gstreamer/pull/45 but has been rebased on `4.0.8`. This branch has been successfully tested in SDK 4.1 with a DeepStream pipeline as well but did require removal of the `image_sync` parameter as that was removed in SDK v4.1._