### PR TITLE
ROI mask is always invalid; Support for auto exposure range in zedsrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,13 @@ Most of the properties follow the same name as the C++ API. Except that `_` is r
                         Integer. Range: 0 - 8 Default: 4 
   ctrl-exposure       : Camera exposure
                         flags: readable, writable
-                        Integer. Range: 0 - 100 Default: 80 
+                        Integer. Range: 0 - 100 Default: 80
+  ctrl-exposure-range-max: Maximum exposure time in microseconds for the automatic exposure setting
+                        flags: readable, writable
+                        Integer. Range: 28 - 66000 Default: 66000 
+  ctrl-exposure-range-min: Minimum exposure time in microseconds for the automatic exposure setting
+                        flags: readable, writable
+                        Integer. Range: 28 - 66000 Default: 28 
   ctrl-gain           : Camera gain
                         flags: readable, writable
                         Integer. Range: 0 - 100 Default: 60 

--- a/gst-zed-src/gstzedsrc.cpp
+++ b/gst-zed-src/gstzedsrc.cpp
@@ -2238,7 +2238,7 @@ static gboolean gst_zedsrc_start(GstBaseSrc *bsrc) {
     init_params.camera_disable_self_calib = src->camera_disable_self_calib == TRUE;
     GST_INFO(" * Disable self calibration: %s",
              (init_params.camera_disable_self_calib ? "TRUE" : "FALSE"));
-		
+    
     sl::String opencv_calibration_file(src->opencv_calibration_file.str);
     init_params.optional_opencv_calibration_file = opencv_calibration_file;
     GST_INFO(" * Calibration File: %s ", init_params.optional_opencv_calibration_file.c_str());
@@ -2368,13 +2368,11 @@ static gboolean gst_zedsrc_start(GstBaseSrc *bsrc) {
                     src->roi_y >= 0 && src->roi_y < resolution.height &&
                     roi_x_end <= resolution.width && roi_y_end <= resolution.height) {
 
-                sl::uchar1 uint0 = 0;
-                sl::uchar1 uint1 = 1;
                 sl::Mat roi_mask(resolution, sl::MAT_TYPE::U8_C1, sl::MEM::CPU);
-                roi_mask.setTo(uint0);
-                for (int row = src->roi_y; row < roi_y_end; row++)
-                    for (int col = src->roi_y; col < roi_x_end; col++)
-                        roi_mask.setValue(col, row, uint1);
+                roi_mask.setTo<sl::uchar1>(0, sl::MEM::CPU);
+                for (unsigned int v = src->roi_y; v < roi_y_end; v++)
+                  for (unsigned int u = src->roi_x; u < roi_x_end; u++)
+                        roi_mask.setValue<sl::uchar1>(u, v, 255, sl::MEM::CPU);
                 
                 GST_INFO(" * ROI mask: (%d,%d)-%dx%d",
                         src->roi_x, src->roi_y, src->roi_w, src->roi_h);

--- a/gst-zed-src/gstzedsrc.h
+++ b/gst-zed-src/gstzedsrc.h
@@ -139,6 +139,8 @@ struct _GstZedSrc {
     gint gamma;
     gint gain;
     gint exposure;
+    gint exposureRange_min;
+    gint exposureRange_max;
     gboolean aec_agc;
     gint aec_agc_roi_x;
     gint aec_agc_roi_y;


### PR DESCRIPTION
Fixes Region of Interest mask always being invalid for the entire image when toggled.

Appears that since SDK v4.0, the Region of Interest matrix can no longer be populated with `1` to indicate that that pixel is valid. Per the [API Reference](https://www.stereolabs.com/docs/api/classsl_1_1Camera.html#afefd8c2cf4f07e7eee47dfe098920eaa), the value must now be >=127. To be safe, I've used 255.

With the current code, if `roi=TRUE`, the depth map will be all 0 (since the ROI matrix will be set as all invalid)