### PR TITLE
Enabled disabling/enabling the recording at runtime

### DIFF
--- a/gst-zed-src/gstzedsrc.h
+++ b/gst-zed-src/gstzedsrc.h
@@ -54,6 +54,8 @@ struct _GstZedSrc {
     gint camera_id;
     gint64 camera_sn;
     GString svo_file;
+    GString rec_file;
+    gboolean recording_status;
     GString opencv_calibration_file;
     GString stream_ip;
     gint stream_port;


### PR DESCRIPTION
Allows the ZED GStreamer to start & stop recordings at runtime.
This is done by passing parameters to the zedsrc.

The two relevant parameters are
- recording-status: gboolean
- recording-filename: GString

Current issues:
- If the filename is not set before trying to record there may be some issues as it will use an empty filepath.
- Probably not organized how you'd like.

I currently have a gstreamer pipeline that is working using these changes.