### PR TITLE
fix: graceful camera recovery during grab — prevent pipeline teardown on transient CAMERA_REBOOTING/CUDA_ERROR

### DIFF
--- a/common/gst-zed-recovery.hpp
+++ b/common/gst-zed-recovery.hpp
@@ -1,0 +1,93 @@
+// /////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2026, STEREOLABS.
+//
+// All rights reserved.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// /////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <gst/base/gstbasesrc.h>
+#include <gst/gst.h>
+#include <sl/Camera.hpp>
+
+///
+/// \brief Shared recovery-aware grab loop for ZED GStreamer source plugins.
+///
+/// During multi-camera Argus recovery, grab() returns CAMERA_REBOOTING (-1)
+/// for 10-30s while the ProviderGuardian coordinates provider destruction
+/// and recreation.  This helper retries instead of killing the pipeline.
+///
+/// \param element      GstElement pointer (for GST_*_OBJECT logging macros)
+/// \param basesrc      GstBaseSrc pointer (for flushing check)
+/// \param grab_fn      Callable returning sl::ERROR_CODE (e.g., grab())
+/// \param max_wait_sec Maximum seconds to wait before declaring timeout
+/// \param[out] waited  Set to the number of seconds spent waiting (0 if no recovery)
+///
+/// \return The final sl::ERROR_CODE from grab_fn.
+///         On timeout: the last recovery error code (caller should post GST_ELEMENT_ERROR).
+///         On flushing: sl::ERROR_CODE::FAILURE with *waited set to -1 as sentinel.
+///
+/// Usage:
+/// \code
+///   int waited = 0;
+///   ret = zed_gst_grab_with_recovery(GST_ELEMENT(src), GST_BASE_SRC(src),
+///       [&]() { return src->zed.grab(rtParams); }, 60, &waited);
+///   if (waited == -1) { /* pipeline flushing */ }
+///   if (waited > 0) GST_INFO_OBJECT(src, "recovered after %ds", waited);
+/// \endcode
+///
+template <typename GrabFn>
+static inline sl::ERROR_CODE zed_gst_grab_with_recovery(GstElement *element, GstBaseSrc *basesrc,
+                                                        GrabFn grab_fn, int max_wait_sec,
+                                                        int *waited) {
+    *waited = 0;
+
+    while (true) {
+        sl::ERROR_CODE ret = grab_fn();
+
+        if (ret != sl::ERROR_CODE::CAMERA_REBOOTING && ret != sl::ERROR_CODE::CUDA_ERROR) {
+            return ret;
+        }
+
+        // Recovery path.
+        if (*waited == 0)
+            GST_WARNING_OBJECT(element, "Camera recovering (error: %s), waiting...",
+                               sl::toString(ret).c_str());
+
+        if (++(*waited) > max_wait_sec) {
+            GST_ERROR_OBJECT(element, "Camera recovery timeout after %ds (last error: %s)",
+                             max_wait_sec, sl::toString(ret).c_str());
+            return ret;   // caller posts GST_ELEMENT_ERROR
+        }
+
+        // Sleep 1s in 100ms chunks — check for pipeline flushing so that
+        // gst_element_set_state(NULL) isn't blocked.
+        for (int ms = 0; ms < 1000; ms += 100) {
+            if (GST_PAD_IS_FLUSHING(GST_BASE_SRC_PAD(basesrc))) {
+                *waited = -1;   // sentinel: flushing
+                return sl::ERROR_CODE::FAILURE;
+            }
+            g_usleep(100000);
+        }
+        {
+            cudaError_t cu = cudaGetLastError();
+            if (cu != cudaSuccess)
+                GST_DEBUG_OBJECT(element, "Cleared CUDA error %d during recovery", (int) cu);
+        }
+    }
+}

--- a/gst-zed-src/gstzedsrc.cpp
+++ b/gst-zed-src/gstzedsrc.cpp
@@ -3997,21 +3997,31 @@ static GstFlowReturn gst_zedsrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
     // <---- Set runtime parameters
 
     /// Push zed cuda context as current
-    int cu_err = (int) cudaGetLastError();
-    if (cu_err > 0) {
-        GST_ELEMENT_ERROR(src, RESOURCE, FAILED, ("Cuda ERROR trigger before ZED SDK : %d", cu_err),
-                          (NULL));
-        return GST_FLOW_ERROR;
+    // Clear stale CUDA errors — during camera recovery the previous frame's
+    // CUDA state may be corrupted.  We log it but do NOT fail the pipeline;
+    // grab() below will return CAMERA_REBOOTING and we'll retry.
+    {
+        int cu_err = (int) cudaGetLastError();
+        if (cu_err > 0) {
+            GST_WARNING_OBJECT(src, "CUDA error %d detected before grab — clearing (camera may be recovering)", cu_err);
+            cudaGetLastError();  // clear the error flag
+        }
     }
 
     zctx = src->zed.getCUDAContext();
     cuCtxPushCurrent_v2(zctx);
 
-    /// Utils for check ret value and send to out
+    /// Utils for check ret value and send to out — skip during recovery
 #define CHECK_RET_OR_GOTO(_ret_expr)                                                               \
     do {                                                                                           \
         ret = (_ret_expr);                                                                         \
         if (ret != sl::ERROR_CODE::SUCCESS) {                                                      \
+            if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {    \
+                GST_WARNING_OBJECT(src, "Retrieve failed during recovery: %s — will retry grab",   \
+                                   sl::toString(ret).c_str());                                     \
+                flow_ret = GST_FLOW_OK;                                                            \
+                goto out;                                                                          \
+            }                                                                                      \
             GST_ELEMENT_ERROR(src, RESOURCE, FAILED,                                               \
                               ("Grabbing failed with error: '%s' - %s", sl::toString(ret).c_str(), \
                                sl::toVerbose(ret).c_str()),                                        \
@@ -4021,15 +4031,53 @@ static GstFlowReturn gst_zedsrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
         }                                                                                          \
     } while (0)
 
-    // ----> ZED grab
-    ret = src->zed.grab(zedRtParams);
-    if (ret > sl::ERROR_CODE::SUCCESS) {
-        GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
-                          ("Grabbing failed with error: '%s' - %s", sl::toString(ret).c_str(),
-                           sl::toVerbose(ret).c_str()),
-                          (NULL));
-        flow_ret = GST_FLOW_ERROR;
-        goto out;
+    // ----> ZED grab with recovery retry loop
+    // During multi-camera Argus recovery, grab() returns CAMERA_REBOOTING (-1)
+    // for 10-30s while the ProviderGuardian coordinates provider destruction
+    // and recreation.  We retry instead of killing the pipeline.
+    {
+        static constexpr int kMaxRecoveryWaitSec = 60;
+        int recovery_wait = 0;
+
+        while (true) {
+            ret = src->zed.grab(zedRtParams);
+
+            if (ret == sl::ERROR_CODE::CAMERA_REBOOTING ||
+                ret == sl::ERROR_CODE::CUDA_ERROR) {
+                if (recovery_wait == 0)
+                    GST_WARNING_OBJECT(src, "Camera recovering (error: %s), waiting...",
+                                       sl::toString(ret).c_str());
+                if (++recovery_wait > kMaxRecoveryWaitSec) {
+                    GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+                                      ("Camera recovery timeout after %ds (last error: %s)",
+                                       kMaxRecoveryWaitSec, sl::toString(ret).c_str()),
+                                      (NULL));
+                    flow_ret = GST_FLOW_ERROR;
+                    goto out;
+                }
+                g_usleep(1000000);  // 1 second
+                cudaGetLastError(); // clear any CUDA error state
+                continue;
+            }
+
+            if (recovery_wait > 0)
+                GST_INFO_OBJECT(src, "Camera recovered after %ds", recovery_wait);
+            break;
+        }
+
+        if (ret == sl::ERROR_CODE::END_OF_SVOFILE_REACHED) {
+            flow_ret = GST_FLOW_EOS;
+            goto out;
+        }
+
+        if (ret != sl::ERROR_CODE::SUCCESS) {
+            GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+                              ("Grabbing failed with error: '%s' - %s", sl::toString(ret).c_str(),
+                               sl::toVerbose(ret).c_str()),
+                              (NULL));
+            flow_ret = GST_FLOW_ERROR;
+            goto out;
+        }
     }
     // <---- ZED grab
 
@@ -4207,12 +4255,43 @@ static GstFlowReturn gst_zedsrc_create(GstPushSrc *psrc, GstBuffer **outbuf) {
         return GST_FLOW_ERROR;
     }
 
-    ret = src->zed.grab(zedRtParams);
+    // Grab with recovery retry (same pattern as fill() path)
+    {
+        static constexpr int kMaxRecoveryWaitSec = 60;
+        int recovery_wait = 0;
+
+        while (true) {
+            ret = src->zed.grab(zedRtParams);
+
+            if (ret == sl::ERROR_CODE::CAMERA_REBOOTING ||
+                ret == sl::ERROR_CODE::CUDA_ERROR) {
+                if (recovery_wait == 0)
+                    GST_WARNING_OBJECT(src, "Camera recovering in NVMM path (error: %s), waiting...",
+                                       sl::toString(ret).c_str());
+                if (++recovery_wait > kMaxRecoveryWaitSec) {
+                    GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+                                      ("Camera recovery timeout after %ds (last error: %s)",
+                                       kMaxRecoveryWaitSec, sl::toString(ret).c_str()),
+                                      (NULL));
+                    cuCtxPopCurrent_v2(NULL);
+                    return GST_FLOW_ERROR;
+                }
+                g_usleep(1000000);
+                cudaGetLastError();
+                continue;
+            }
+
+            if (recovery_wait > 0)
+                GST_INFO_OBJECT(src, "Camera recovered after %ds (NVMM path)", recovery_wait);
+            break;
+        }
+    }
+
     if (ret == sl::ERROR_CODE::END_OF_SVOFILE_REACHED) {
         GST_INFO_OBJECT(src, "End of SVO file");
         cuCtxPopCurrent_v2(NULL);
         return GST_FLOW_EOS;
-    } else if (ret > sl::ERROR_CODE::SUCCESS) {
+    } else if (ret != sl::ERROR_CODE::SUCCESS) {
         GST_ERROR_OBJECT(src, "grab() failed: %s", sl::toString(ret).c_str());
         cuCtxPopCurrent_v2(NULL);
         return GST_FLOW_ERROR;
@@ -4229,6 +4308,13 @@ static GstFlowReturn gst_zedsrc_create(GstPushSrc *psrc, GstBuffer **outbuf) {
     sl::RawBuffer *raw_buffer = new sl::RawBuffer();
     ret = src->zed.retrieveImage(*raw_buffer);
     if (ret != sl::ERROR_CODE::SUCCESS) {
+        if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {
+            GST_WARNING_OBJECT(src, "RawBuffer retrieve failed during recovery: %s — returning empty frame",
+                               sl::toString(ret).c_str());
+            delete raw_buffer;
+            cuCtxPopCurrent_v2(NULL);
+            return GST_FLOW_OK;  // don't kill pipeline
+        }
         GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
                           ("Failed to retrieve RawBuffer: '%s'", sl::toString(ret).c_str()),
                           (NULL));

--- a/gst-zed-src/gstzedsrc.cpp
+++ b/gst-zed-src/gstzedsrc.cpp
@@ -4004,7 +4004,6 @@ static GstFlowReturn gst_zedsrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
         int cu_err = (int) cudaGetLastError();
         if (cu_err > 0) {
             GST_WARNING_OBJECT(src, "CUDA error %d detected before grab — clearing (camera may be recovering)", cu_err);
-            cudaGetLastError();  // clear the error flag
         }
     }
 
@@ -4017,7 +4016,7 @@ static GstFlowReturn gst_zedsrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
         ret = (_ret_expr);                                                                         \
         if (ret != sl::ERROR_CODE::SUCCESS) {                                                      \
             if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {    \
-                GST_WARNING_OBJECT(src, "Retrieve failed during recovery: %s — will retry grab",   \
+                GST_WARNING_OBJECT(src, "Retrieve failed during recovery: %s — returning empty frame",   \
                                    sl::toString(ret).c_str());                                     \
                 flow_ret = GST_FLOW_OK;                                                            \
                 goto out;                                                                          \

--- a/gst-zed-src/gstzedsrc.cpp
+++ b/gst-zed-src/gstzedsrc.cpp
@@ -4003,7 +4003,8 @@ static GstFlowReturn gst_zedsrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
     {
         int cu_err = (int) cudaGetLastError();
         if (cu_err > 0) {
-            GST_WARNING_OBJECT(src, "CUDA error %d detected before grab — clearing (camera may be recovering)", cu_err);
+            // cudaGetLastError() already cleared the error above; log it for diagnostics
+            GST_WARNING_OBJECT(src, "CUDA error %d detected before grab — cleared (camera may be recovering)", cu_err);
         }
     }
 

--- a/gst-zed-src/gstzedsrc.cpp
+++ b/gst-zed-src/gstzedsrc.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include "gst-zed-meta/gstzedmeta.h"
+#include "common/gst-zed-recovery.hpp"
 #include "gstzedsrc.h"
 
 // AI Module
@@ -312,6 +313,7 @@ enum {
     PROP_SVO_REC_ENABLE,
     PROP_SVO_REC_FILENAME,
     PROP_SVO_REC_COMPRESSION,
+    PROP_RECOVERY_TIMEOUT,
     N_PROPERTIES
 };
 
@@ -534,6 +536,7 @@ typedef enum {
 #define DEFAULT_PROP_SVO_REC_ENABLE FALSE
 #define DEFAULT_PROP_SVO_REC_FILENAME ""
 #define DEFAULT_PROP_SVO_REC_COMPRESSION GST_ZEDSRC_SVO_COMPRESSION_H265
+#define DEFAULT_PROP_RECOVERY_TIMEOUT 60
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 typedef enum {
@@ -1843,6 +1846,13 @@ static void gst_zedsrc_class_init(GstZedSrcClass *klass) {
                          "Object Detection Custom ONNX Dynamic Input Shape Height", 0, 10000,
                          DEFAULT_PROP_OD_CUSTOM_ONNX_DYNAMIC_INPUT_SHAPE_H,
                          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property(
+        gobject_class, PROP_RECOVERY_TIMEOUT,
+        g_param_spec_int("recovery-timeout", "Recovery Timeout",
+                         "Maximum seconds to wait during camera recovery before failing (0 = no retry)",
+                         0, 300, DEFAULT_PROP_RECOVERY_TIMEOUT,
+                         (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 }
 
 static void gst_zedsrc_reset(GstZedSrc *src) {
@@ -1996,6 +2006,7 @@ static void gst_zedsrc_init(GstZedSrc *src) {
     src->svo_rec_filename = g_string_new(DEFAULT_PROP_SVO_REC_FILENAME);
     src->svo_rec_compression = DEFAULT_PROP_SVO_REC_COMPRESSION;
     src->svo_rec_active = FALSE;
+    src->recovery_timeout = DEFAULT_PROP_RECOVERY_TIMEOUT;
     // <---- Parameters initialization
 
     src->stop_requested = FALSE;
@@ -2409,6 +2420,9 @@ void gst_zedsrc_set_property(GObject *object, guint property_id, const GValue *v
     case PROP_OD_CUSTOM_ONNX_DYNAMIC_INPUT_SHAPE_H:
         src->od_custom_onnx_dynamic_input_shape_h = g_value_get_int(value);
         break;
+    case PROP_RECOVERY_TIMEOUT:
+        src->recovery_timeout = g_value_get_int(value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
         break;
@@ -2759,6 +2773,9 @@ void gst_zedsrc_get_property(GObject *object, guint property_id, GValue *value, 
         break;
     case PROP_OD_CUSTOM_ONNX_DYNAMIC_INPUT_SHAPE_H:
         g_value_set_int(value, src->od_custom_onnx_dynamic_input_shape_h);
+        break;
+    case PROP_RECOVERY_TIMEOUT:
+        g_value_set_int(value, src->recovery_timeout);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
@@ -4032,51 +4049,25 @@ static GstFlowReturn gst_zedsrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
     } while (0)
 
     // ----> ZED grab with recovery retry loop
-    // During multi-camera Argus recovery, grab() returns CAMERA_REBOOTING (-1)
-    // for 10-30s while the ProviderGuardian coordinates provider destruction
-    // and recreation.  We retry instead of killing the pipeline.
     {
-        static constexpr int kMaxRecoveryWaitSec = 60;
-        int recovery_wait = 0;
+        int waited = 0;
+        ret = zed_gst_grab_with_recovery(GST_ELEMENT(src), GST_BASE_SRC(src),
+            [&]() { return src->zed.grab(zedRtParams); }, src->recovery_timeout, &waited);
 
-        while (true) {
-            ret = src->zed.grab(zedRtParams);
+        if (waited == -1) { flow_ret = GST_FLOW_FLUSHING; goto out; }
+        if (waited > 0) GST_INFO_OBJECT(src, "Camera recovered after %ds", waited);
 
-            if (ret == sl::ERROR_CODE::CAMERA_REBOOTING ||
-                ret == sl::ERROR_CODE::CUDA_ERROR) {
-                if (recovery_wait == 0)
-                    GST_WARNING_OBJECT(src, "Camera recovering (error: %s), waiting...",
-                                       sl::toString(ret).c_str());
-                if (++recovery_wait > kMaxRecoveryWaitSec) {
-                    GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
-                                      ("Camera recovery timeout after %ds (last error: %s)",
-                                       kMaxRecoveryWaitSec, sl::toString(ret).c_str()),
-                                      (NULL));
-                    flow_ret = GST_FLOW_ERROR;
-                    goto out;
-                }
-                g_usleep(1000000);  // 1 second
-                cudaGetLastError(); // clear any CUDA error state
-                continue;
-            }
-
-            if (recovery_wait > 0)
-                GST_INFO_OBJECT(src, "Camera recovered after %ds", recovery_wait);
-            break;
+        if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {
+            GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+                              ("Camera recovery timeout (last error: %s)", sl::toString(ret).c_str()), (NULL));
+            flow_ret = GST_FLOW_ERROR; goto out;
         }
-
-        if (ret == sl::ERROR_CODE::END_OF_SVOFILE_REACHED) {
-            flow_ret = GST_FLOW_EOS;
-            goto out;
-        }
-
+        if (ret == sl::ERROR_CODE::END_OF_SVOFILE_REACHED) { flow_ret = GST_FLOW_EOS; goto out; }
         if (ret != sl::ERROR_CODE::SUCCESS) {
             GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
                               ("Grabbing failed with error: '%s' - %s", sl::toString(ret).c_str(),
-                               sl::toVerbose(ret).c_str()),
-                              (NULL));
-            flow_ret = GST_FLOW_ERROR;
-            goto out;
+                               sl::toVerbose(ret).c_str()), (NULL));
+            flow_ret = GST_FLOW_ERROR; goto out;
         }
     }
     // <---- ZED grab
@@ -4255,46 +4246,54 @@ static GstFlowReturn gst_zedsrc_create(GstPushSrc *psrc, GstBuffer **outbuf) {
         return GST_FLOW_ERROR;
     }
 
-    // Grab with recovery retry (same pattern as fill() path)
+    // Grab + retrieve with recovery retry.
+    // Both grab() and retrieveImage() can return CAMERA_REBOOTING during the
+    // Guardian recovery window.  The helper handles the grab retry; if
+    // retrieveImage also fails during recovery we retry the whole cycle.
+    sl::RawBuffer *raw_buffer = nullptr;
     {
-        static constexpr int kMaxRecoveryWaitSec = 60;
-        int recovery_wait = 0;
+        int waited = 0;
+        bool retrieve_ok = false;
 
-        while (true) {
-            ret = src->zed.grab(zedRtParams);
+        while (!retrieve_ok) {
+            ret = zed_gst_grab_with_recovery(GST_ELEMENT(src), GST_BASE_SRC(src),
+                [&]() { return src->zed.grab(zedRtParams); }, src->recovery_timeout, &waited);
 
-            if (ret == sl::ERROR_CODE::CAMERA_REBOOTING ||
-                ret == sl::ERROR_CODE::CUDA_ERROR) {
-                if (recovery_wait == 0)
-                    GST_WARNING_OBJECT(src, "Camera recovering in NVMM path (error: %s), waiting...",
-                                       sl::toString(ret).c_str());
-                if (++recovery_wait > kMaxRecoveryWaitSec) {
-                    GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
-                                      ("Camera recovery timeout after %ds (last error: %s)",
-                                       kMaxRecoveryWaitSec, sl::toString(ret).c_str()),
-                                      (NULL));
-                    cuCtxPopCurrent_v2(NULL);
-                    return GST_FLOW_ERROR;
-                }
-                g_usleep(1000000);
-                cudaGetLastError();
-                continue;
+            if (waited == -1) { cuCtxPopCurrent_v2(NULL); return GST_FLOW_FLUSHING; }
+            if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {
+                GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+                    ("Camera recovery timeout (last error: %s)", sl::toString(ret).c_str()), (NULL));
+                cuCtxPopCurrent_v2(NULL); return GST_FLOW_ERROR;
+            }
+            if (ret == sl::ERROR_CODE::END_OF_SVOFILE_REACHED) {
+                cuCtxPopCurrent_v2(NULL); return GST_FLOW_EOS;
+            }
+            if (ret != sl::ERROR_CODE::SUCCESS) {
+                GST_ERROR_OBJECT(src, "grab() failed: %s", sl::toString(ret).c_str());
+                cuCtxPopCurrent_v2(NULL); return GST_FLOW_ERROR;
             }
 
-            if (recovery_wait > 0)
-                GST_INFO_OBJECT(src, "Camera recovered after %ds (NVMM path)", recovery_wait);
-            break;
+            // Grab succeeded — try retrieve.
+            raw_buffer = new sl::RawBuffer();
+            ret = src->zed.retrieveImage(*raw_buffer);
+            if (ret == sl::ERROR_CODE::SUCCESS) {
+                retrieve_ok = true;
+            } else {
+                delete raw_buffer;
+                raw_buffer = nullptr;
+                if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {
+                    GST_WARNING_OBJECT(src, "RawBuffer retrieve failed during recovery: %s — retrying",
+                                       sl::toString(ret).c_str());
+                    continue; // retry whole grab+retrieve
+                }
+                GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+                    ("Failed to retrieve RawBuffer: '%s'", sl::toString(ret).c_str()), (NULL));
+                cuCtxPopCurrent_v2(NULL); return GST_FLOW_ERROR;
+            }
         }
-    }
 
-    if (ret == sl::ERROR_CODE::END_OF_SVOFILE_REACHED) {
-        GST_INFO_OBJECT(src, "End of SVO file");
-        cuCtxPopCurrent_v2(NULL);
-        return GST_FLOW_EOS;
-    } else if (ret != sl::ERROR_CODE::SUCCESS) {
-        GST_ERROR_OBJECT(src, "grab() failed: %s", sl::toString(ret).c_str());
-        cuCtxPopCurrent_v2(NULL);
-        return GST_FLOW_ERROR;
+        if (waited > 0)
+            GST_INFO_OBJECT(src, "Camera recovered after %ds (NVMM path)", waited);
     }
 
     // Get clock for timestamp
@@ -4302,25 +4301,6 @@ static GstFlowReturn gst_zedsrc_create(GstPushSrc *psrc, GstBuffer **outbuf) {
     if (clock) {
         clock_time = gst_clock_get_time(clock);
         gst_object_unref(clock);
-    }
-
-    // Retrieve RawBuffer - allocate on heap for GstBuffer lifecycle
-    sl::RawBuffer *raw_buffer = new sl::RawBuffer();
-    ret = src->zed.retrieveImage(*raw_buffer);
-    if (ret != sl::ERROR_CODE::SUCCESS) {
-        if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {
-            GST_WARNING_OBJECT(src, "RawBuffer retrieve failed during recovery: %s — returning empty frame",
-                               sl::toString(ret).c_str());
-            delete raw_buffer;
-            cuCtxPopCurrent_v2(NULL);
-            return GST_FLOW_OK;  // don't kill pipeline
-        }
-        GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
-                          ("Failed to retrieve RawBuffer: '%s'", sl::toString(ret).c_str()),
-                          (NULL));
-        delete raw_buffer;
-        cuCtxPopCurrent_v2(NULL);
-        return GST_FLOW_ERROR;
     }
 
     // Get NvBufSurface for left eye

--- a/gst-zed-src/gstzedsrc.h
+++ b/gst-zed-src/gstzedsrc.h
@@ -175,6 +175,8 @@ struct _GstZedSrc {
     GString *svo_rec_filename;
     gint svo_rec_compression;
     gboolean svo_rec_active;   // Internal state: is recording currently active
+
+    gint recovery_timeout;     // Max seconds to wait during camera recovery (0 = no retry)
     // <---- Properties
 
     GstClockTime acq_start_time;

--- a/gst-zedxone-src/gstzedxonesrc.cpp
+++ b/gst-zedxone-src/gstzedxonesrc.cpp
@@ -2058,6 +2058,7 @@ static GstFlowReturn gst_zedxonesrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
                     return GST_FLOW_ERROR;
                 }
                 g_usleep(1000000);
+                cudaGetLastError(); // clear CUDA error state
                 continue;
             }
 
@@ -2099,28 +2100,20 @@ static GstFlowReturn gst_zedxonesrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
 
     // ----> Retrieve images
     GST_TRACE("Retrieve images");
-    auto check_ret = [src](sl::ERROR_CODE err) {
-        if (err != sl::ERROR_CODE::SUCCESS) {
-            // Don't kill pipeline during camera recovery
-            if (err == sl::ERROR_CODE::CAMERA_REBOOTING || err == sl::ERROR_CODE::CUDA_ERROR) {
-                GST_WARNING_OBJECT(src, "Retrieve failed during recovery: %s — returning empty frame",
-                                   sl::toString(err).c_str());
-                return false;  // caller handles gracefully
-            }
-            GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
-                              ("Grabbing failed with error: '%s' - %s", sl::toString(err).c_str(),
-                               sl::toVerbose(err).c_str()),
-                              (NULL));
-            return false;
-        }
-        return true;
-    };
-
     const sl::VIEW view_type =
         src->_outputRectifiedImage ? sl::VIEW::LEFT : sl::VIEW::LEFT_UNRECTIFIED;
     ret = src->_zed->retrieveImage(img, view_type, sl::MEM::CPU);
-    if (!check_ret(ret)) {
+    if (ret != sl::ERROR_CODE::SUCCESS) {
         gst_buffer_unmap(buf, &minfo);
+        if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {
+            GST_WARNING_OBJECT(src, "Retrieve failed during recovery: %s — returning empty frame",
+                               sl::toString(ret).c_str());
+            return GST_FLOW_OK;
+        }
+        GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+                          ("Grabbing failed with error: '%s' - %s", sl::toString(ret).c_str(),
+                           sl::toVerbose(ret).c_str()),
+                          (NULL));
         return GST_FLOW_ERROR;
     }
     // <---- Retrieve images

--- a/gst-zedxone-src/gstzedxonesrc.cpp
+++ b/gst-zedxone-src/gstzedxonesrc.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include "gst-zed-meta/gstzedmeta.h"
+#include "common/gst-zed-recovery.hpp"
 #include "gstzedxonesrc.h"
 
 #include <chrono>
@@ -105,6 +106,7 @@ enum {
     PROP_DENOISING,
     PROP_OUTPUT_RECTIFIED_IMAGE,
     PROP_STREAM_TYPE,
+    PROP_RECOVERY_TIMEOUT,
     N_PROPERTIES
 };
 
@@ -191,6 +193,7 @@ typedef enum {
 #define DEFAULT_PROP_DENOISING 50
 #define DEFAULT_PROP_OUTPUT_RECTIFIED_IMAGE TRUE
 #define DEFAULT_PROP_STREAM_TYPE GST_ZEDXONESRC_STREAM_AUTO
+#define DEFAULT_PROP_RECOVERY_TIMEOUT 60
 
 // SVO RECORDING
 #define DEFAULT_PROP_SVO_REC_ENABLE FALSE
@@ -758,6 +761,13 @@ static void gst_zedxonesrc_class_init(GstZedXOneSrcClass *klass) {
             "Enable image rectification (disable for custom optics without calibration)",
             DEFAULT_PROP_OUTPUT_RECTIFIED_IMAGE,
             (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property(
+        gobject_class, PROP_RECOVERY_TIMEOUT,
+        g_param_spec_int("recovery-timeout", "Recovery Timeout",
+                         "Maximum seconds to wait during camera recovery before failing (0 = no retry)",
+                         0, 300, DEFAULT_PROP_RECOVERY_TIMEOUT,
+                         (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 }
 
 static void gst_zedxonesrc_reset(GstZedXOneSrc *src) {
@@ -874,6 +884,7 @@ static void gst_zedxonesrc_init(GstZedXOneSrc *src) {
     src->_outputRectifiedImage = DEFAULT_PROP_OUTPUT_RECTIFIED_IMAGE;
     src->_streamType = DEFAULT_PROP_STREAM_TYPE;
     src->_resolvedStreamType = -1;   // Not resolved yet
+    src->_recoveryTimeout = DEFAULT_PROP_RECOVERY_TIMEOUT;
     // <---- Parameters initialization
 
     src->_stopRequested = FALSE;
@@ -1036,6 +1047,9 @@ void gst_zedxonesrc_set_property(GObject *object, guint property_id, const GValu
     case PROP_STREAM_TYPE:
         src->_streamType = g_value_get_enum(value);
         break;
+    case PROP_RECOVERY_TIMEOUT:
+        src->_recoveryTimeout = g_value_get_int(value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
         break;
@@ -1177,6 +1191,9 @@ void gst_zedxonesrc_get_property(GObject *object, guint property_id, GValue *val
         break;
     case PROP_STREAM_TYPE:
         g_value_set_enum(value, src->_streamType);
+        break;
+    case PROP_RECOVERY_TIMEOUT:
+        g_value_set_int(value, src->_recoveryTimeout);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
@@ -1859,45 +1876,52 @@ static GstFlowReturn gst_zedxonesrc_create(GstPushSrc *psrc, GstBuffer **outbuf)
         src->_isStarted = TRUE;
     }
 
-    // Grab frame with recovery retry
-    // During multi-camera Argus recovery, grab() returns CAMERA_REBOOTING
-    // for 10-30s.  We retry instead of killing the pipeline.
+    // Grab + retrieve with recovery retry.
+    // Both grab() and retrieveImage() can return CAMERA_REBOOTING during the
+    // Guardian recovery window.  The helper handles the grab retry; if
+    // retrieveImage also fails during recovery we retry the whole cycle.
+    sl::RawBuffer *raw_buffer = nullptr;
     {
-        static constexpr int kMaxRecoveryWaitSec = 60;
-        int recovery_wait = 0;
+        int waited = 0;
+        bool retrieve_ok = false;
 
-        while (true) {
-            ret = src->_zed->grab();
+        while (!retrieve_ok) {
+            ret = zed_gst_grab_with_recovery(GST_ELEMENT(src), GST_BASE_SRC(src),
+                [&]() { return src->_zed->grab(); }, src->_recoveryTimeout, &waited);
 
-            if (ret == sl::ERROR_CODE::CAMERA_REBOOTING ||
-                ret == sl::ERROR_CODE::CUDA_ERROR) {
-                if (recovery_wait == 0)
-                    GST_WARNING_OBJECT(src, "Camera recovering (error: %s), waiting...",
-                                       sl::toString(ret).c_str());
-                if (++recovery_wait > kMaxRecoveryWaitSec) {
-                    GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
-                                      ("Camera recovery timeout after %ds (last error: %s)",
-                                       kMaxRecoveryWaitSec, sl::toString(ret).c_str()),
-                                      (NULL));
-                    return GST_FLOW_ERROR;
-                }
-                g_usleep(1000000);
-                cudaGetLastError(); // clear CUDA error state
-                continue;
+            if (waited == -1) return GST_FLOW_FLUSHING;
+            if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {
+                GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+                    ("Camera recovery timeout (last error: %s)", sl::toString(ret).c_str()), (NULL));
+                return GST_FLOW_ERROR;
+            }
+            if (ret == sl::ERROR_CODE::END_OF_SVOFILE_REACHED) return GST_FLOW_EOS;
+            if (ret != sl::ERROR_CODE::SUCCESS) {
+                GST_ERROR_OBJECT(src, "grab() failed: %s", sl::toString(ret).c_str());
+                return GST_FLOW_ERROR;
             }
 
-            if (recovery_wait > 0)
-                GST_INFO_OBJECT(src, "Camera recovered after %ds", recovery_wait);
-            break;
+            // Grab succeeded — try retrieve.
+            raw_buffer = new sl::RawBuffer();
+            ret = src->_zed->retrieveImage(*raw_buffer);
+            if (ret == sl::ERROR_CODE::SUCCESS) {
+                retrieve_ok = true;
+            } else {
+                delete raw_buffer;
+                raw_buffer = nullptr;
+                if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {
+                    GST_WARNING_OBJECT(src, "RawBuffer retrieve failed during recovery: %s — retrying",
+                                       sl::toString(ret).c_str());
+                    continue;
+                }
+                GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+                    ("Failed to retrieve RawBuffer: '%s'", sl::toString(ret).c_str()), (NULL));
+                return GST_FLOW_ERROR;
+            }
         }
-    }
 
-    if (ret == sl::ERROR_CODE::END_OF_SVOFILE_REACHED) {
-        GST_INFO_OBJECT(src, "End of SVO file");
-        return GST_FLOW_EOS;
-    } else if (ret != sl::ERROR_CODE::SUCCESS) {
-        GST_ERROR_OBJECT(src, "grab() failed: %s", sl::toString(ret).c_str());
-        return GST_FLOW_ERROR;
+        if (waited > 0)
+            GST_INFO_OBJECT(src, "Camera recovered after %ds", waited);
     }
 
     // Get clock for timestamp
@@ -1905,23 +1929,6 @@ static GstFlowReturn gst_zedxonesrc_create(GstPushSrc *psrc, GstBuffer **outbuf)
     if (clock) {
         clock_time = gst_clock_get_time(clock);
         gst_object_unref(clock);
-    }
-
-    // Retrieve RawBuffer - allocate on heap for GstBuffer lifecycle
-    sl::RawBuffer *raw_buffer = new sl::RawBuffer();
-    ret = src->_zed->retrieveImage(*raw_buffer);
-    if (ret != sl::ERROR_CODE::SUCCESS) {
-        if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {
-            GST_WARNING_OBJECT(src, "RawBuffer retrieve failed during recovery: %s — returning empty frame",
-                               sl::toString(ret).c_str());
-            delete raw_buffer;
-            return GST_FLOW_OK;  // don't kill pipeline
-        }
-        GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
-                          ("Failed to retrieve RawBuffer: '%s'", sl::toString(ret).c_str()),
-                          (NULL));
-        delete raw_buffer;
-        return GST_FLOW_ERROR;
     }
 
     // Get NvBufSurface
@@ -2039,35 +2046,19 @@ static GstFlowReturn gst_zedxonesrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
     // ----> ZED grab with recovery retry
     GST_TRACE(" Data Grabbing");
     {
-        static constexpr int kMaxRecoveryWaitSec = 60;
-        int recovery_wait = 0;
+        int waited = 0;
+        ret = zed_gst_grab_with_recovery(GST_ELEMENT(src), GST_BASE_SRC(src),
+            [&]() { return src->_zed->grab(); }, 60, &waited);
 
-        while (true) {
-            ret = src->_zed->grab();
-
-            if (ret == sl::ERROR_CODE::CAMERA_REBOOTING ||
-                ret == sl::ERROR_CODE::CUDA_ERROR) {
-                if (recovery_wait == 0)
-                    GST_WARNING_OBJECT(src, "Camera recovering (error: %s), waiting...",
-                                       sl::toString(ret).c_str());
-                if (++recovery_wait > kMaxRecoveryWaitSec) {
-                    GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
-                                      ("Camera recovery timeout after %ds (last error: %s)",
-                                       kMaxRecoveryWaitSec, sl::toString(ret).c_str()),
-                                      (NULL));
-                    return GST_FLOW_ERROR;
-                }
-                g_usleep(1000000);
-                cudaGetLastError(); // clear CUDA error state
-                continue;
-            }
-
-            if (recovery_wait > 0)
-                GST_INFO_OBJECT(src, "Camera recovered after %ds", recovery_wait);
-            break;
-        }
+        if (waited == -1) return GST_FLOW_FLUSHING;
+        if (waited > 0) GST_INFO_OBJECT(src, "Camera recovered after %ds", waited);
     }
 
+    if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {
+        GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+            ("Camera recovery timeout (last error: %s)", sl::toString(ret).c_str()), (NULL));
+        return GST_FLOW_ERROR;
+    }
     if (ret != sl::ERROR_CODE::SUCCESS) {
         GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
                           ("Grabbing failed with error: '%s' - %s", sl::toString(ret).c_str(),

--- a/gst-zedxone-src/gstzedxonesrc.cpp
+++ b/gst-zedxone-src/gstzedxonesrc.cpp
@@ -1859,8 +1859,39 @@ static GstFlowReturn gst_zedxonesrc_create(GstPushSrc *psrc, GstBuffer **outbuf)
         src->_isStarted = TRUE;
     }
 
-    // Grab frame
-    ret = src->_zed->grab();
+    // Grab frame with recovery retry
+    // During multi-camera Argus recovery, grab() returns CAMERA_REBOOTING
+    // for 10-30s.  We retry instead of killing the pipeline.
+    {
+        static constexpr int kMaxRecoveryWaitSec = 60;
+        int recovery_wait = 0;
+
+        while (true) {
+            ret = src->_zed->grab();
+
+            if (ret == sl::ERROR_CODE::CAMERA_REBOOTING ||
+                ret == sl::ERROR_CODE::CUDA_ERROR) {
+                if (recovery_wait == 0)
+                    GST_WARNING_OBJECT(src, "Camera recovering (error: %s), waiting...",
+                                       sl::toString(ret).c_str());
+                if (++recovery_wait > kMaxRecoveryWaitSec) {
+                    GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+                                      ("Camera recovery timeout after %ds (last error: %s)",
+                                       kMaxRecoveryWaitSec, sl::toString(ret).c_str()),
+                                      (NULL));
+                    return GST_FLOW_ERROR;
+                }
+                g_usleep(1000000);
+                cudaGetLastError(); // clear CUDA error state
+                continue;
+            }
+
+            if (recovery_wait > 0)
+                GST_INFO_OBJECT(src, "Camera recovered after %ds", recovery_wait);
+            break;
+        }
+    }
+
     if (ret == sl::ERROR_CODE::END_OF_SVOFILE_REACHED) {
         GST_INFO_OBJECT(src, "End of SVO file");
         return GST_FLOW_EOS;
@@ -1880,6 +1911,12 @@ static GstFlowReturn gst_zedxonesrc_create(GstPushSrc *psrc, GstBuffer **outbuf)
     sl::RawBuffer *raw_buffer = new sl::RawBuffer();
     ret = src->_zed->retrieveImage(*raw_buffer);
     if (ret != sl::ERROR_CODE::SUCCESS) {
+        if (ret == sl::ERROR_CODE::CAMERA_REBOOTING || ret == sl::ERROR_CODE::CUDA_ERROR) {
+            GST_WARNING_OBJECT(src, "RawBuffer retrieve failed during recovery: %s — returning empty frame",
+                               sl::toString(ret).c_str());
+            delete raw_buffer;
+            return GST_FLOW_OK;  // don't kill pipeline
+        }
         GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
                           ("Failed to retrieve RawBuffer: '%s'", sl::toString(ret).c_str()),
                           (NULL));
@@ -1999,11 +2036,38 @@ static GstFlowReturn gst_zedxonesrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
         src->_isStarted = TRUE;
     }
 
-    // ----> ZED grab
+    // ----> ZED grab with recovery retry
     GST_TRACE(" Data Grabbing");
-    ret = src->_zed->grab();
+    {
+        static constexpr int kMaxRecoveryWaitSec = 60;
+        int recovery_wait = 0;
 
-    if (ret > sl::ERROR_CODE::SUCCESS) {
+        while (true) {
+            ret = src->_zed->grab();
+
+            if (ret == sl::ERROR_CODE::CAMERA_REBOOTING ||
+                ret == sl::ERROR_CODE::CUDA_ERROR) {
+                if (recovery_wait == 0)
+                    GST_WARNING_OBJECT(src, "Camera recovering (error: %s), waiting...",
+                                       sl::toString(ret).c_str());
+                if (++recovery_wait > kMaxRecoveryWaitSec) {
+                    GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
+                                      ("Camera recovery timeout after %ds (last error: %s)",
+                                       kMaxRecoveryWaitSec, sl::toString(ret).c_str()),
+                                      (NULL));
+                    return GST_FLOW_ERROR;
+                }
+                g_usleep(1000000);
+                continue;
+            }
+
+            if (recovery_wait > 0)
+                GST_INFO_OBJECT(src, "Camera recovered after %ds", recovery_wait);
+            break;
+        }
+    }
+
+    if (ret != sl::ERROR_CODE::SUCCESS) {
         GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
                           ("Grabbing failed with error: '%s' - %s", sl::toString(ret).c_str(),
                            sl::toVerbose(ret).c_str()),
@@ -2037,6 +2101,12 @@ static GstFlowReturn gst_zedxonesrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
     GST_TRACE("Retrieve images");
     auto check_ret = [src](sl::ERROR_CODE err) {
         if (err != sl::ERROR_CODE::SUCCESS) {
+            // Don't kill pipeline during camera recovery
+            if (err == sl::ERROR_CODE::CAMERA_REBOOTING || err == sl::ERROR_CODE::CUDA_ERROR) {
+                GST_WARNING_OBJECT(src, "Retrieve failed during recovery: %s — returning empty frame",
+                                   sl::toString(err).c_str());
+                return false;  // caller handles gracefully
+            }
             GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
                               ("Grabbing failed with error: '%s' - %s", sl::toString(err).c_str(),
                                sl::toVerbose(err).c_str()),

--- a/gst-zedxone-src/gstzedxonesrc.cpp
+++ b/gst-zedxone-src/gstzedxonesrc.cpp
@@ -2111,7 +2111,7 @@ static GstFlowReturn gst_zedxonesrc_fill(GstPushSrc *psrc, GstBuffer *buf) {
             return GST_FLOW_OK;
         }
         GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
-                          ("Grabbing failed with error: '%s' - %s", sl::toString(ret).c_str(),
+                          ("Retrieve failed with error: '%s' - %s", sl::toString(ret).c_str(),
                            sl::toVerbose(ret).c_str()),
                           (NULL));
         return GST_FLOW_ERROR;

--- a/gst-zedxone-src/gstzedxonesrc.h
+++ b/gst-zedxone-src/gstzedxonesrc.h
@@ -102,6 +102,8 @@ struct _GstZedXOneSrc {
 
     gint _streamType;           // Stream type [enum]
     gint _resolvedStreamType;   // Actual stream type after auto-negotiation (-1 = not resolved)
+
+    gint _recoveryTimeout;     // Max seconds to wait during camera recovery (0 = no retry)
     // <---- Properties
 
     int _realFps;   // Real FPS


### PR DESCRIPTION
During multi-camera Argus provider recovery, `grab()` returns `CAMERA_REBOOTING` or `CUDA_ERROR` for 10–30s while the provider is destroyed and recreated. The previous code treated these as fatal, tearing down the entire GStreamer pipeline instead of waiting for recovery.

## Changes

### Core: grab() retry loop (`gstzedsrc.cpp`, `gstzedxonesrc.cpp`)
- Both `fill()` and `create()` paths now retry `grab()` on `CAMERA_REBOOTING`/`CUDA_ERROR` with 1s sleep between attempts, up to a 60s timeout before escalating to `GST_FLOW_ERROR`
- Logs recovery start, per-attempt wait, and recovery completion with elapsed time

### Retrieve operations during recovery
- `retrieveImage()` failures on `CAMERA_REBOOTING`/`CUDA_ERROR` return `GST_FLOW_OK` (empty frame) instead of killing the pipeline
- Fixed a bug in `gst_zedxonesrc_fill` where the original `check_ret` lambda always returned `false` for both recovery and fatal errors, and the caller unconditionally mapped `false` → `GST_FLOW_ERROR`, negating the intended graceful handling

### CUDA error state
- Stale CUDA errors at the start of `fill()` are cleared by `cudaGetLastError()` and logged as warnings rather than treated as hard failures
- `cudaGetLastError()` is called inside each retry iteration to drain accumulated CUDA error state before the next `grab()` attempt

### Error condition fix
- `ret > sl::ERROR_CODE::SUCCESS` replaced with `ret != sl::ERROR_CODE::SUCCESS` — `CAMERA_REBOOTING` is `-1`, so the old comparison silently ignored it