### PR TITLE
Fix NV12 SBS nvjpegenc surface registration faults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,5 @@ my-plugin-*.tar.*
 *.autosave
 *.user
 *.user.*
-<<<<<<< HEAD
+__pycache__/
 *build*
-=======
->>>>>>> master
-

--- a/gst-zed-src/gstzedsrc.cpp
+++ b/gst-zed-src/gstzedsrc.cpp
@@ -149,9 +149,12 @@ static gboolean gst_zedsrc_sbs_pool_ensure(GstZedSrc *src, const NvBufSurfaceCre
     }
 
     if (src->sbs_pool) {
-        gst_buffer_pool_set_active(src->sbs_pool, FALSE);
-        gst_object_unref(src->sbs_pool);
+        GST_OBJECT_LOCK(src);
+        GstBufferPool *old_pool = src->sbs_pool;
         src->sbs_pool = NULL;
+        GST_OBJECT_UNLOCK(src);
+        gst_buffer_pool_set_active(old_pool, FALSE);
+        gst_object_unref(old_pool);
     }
 
     GstBufferPool *pool = static_cast<GstBufferPool *>(g_object_new(GST_TYPE_ZED_SBS_POOL, NULL));
@@ -166,7 +169,9 @@ static gboolean gst_zedsrc_sbs_pool_ensure(GstZedSrc *src, const NvBufSurfaceCre
         return FALSE;
     }
 
+    GST_OBJECT_LOCK(src);
     src->sbs_pool = pool;
+    GST_OBJECT_UNLOCK(src);
     src->sbs_pool_width = cp->width;
     src->sbs_pool_height = cp->height;
     src->sbs_pool_gpu_id = cp->gpuId;
@@ -177,10 +182,13 @@ static gboolean gst_zedsrc_sbs_pool_ensure(GstZedSrc *src, const NvBufSurfaceCre
 }
 
 static void gst_zedsrc_sbs_pool_release(GstZedSrc *src) {
-    if (src->sbs_pool) {
-        gst_buffer_pool_set_active(src->sbs_pool, FALSE);
-        gst_object_unref(src->sbs_pool);
-        src->sbs_pool = NULL;
+    GST_OBJECT_LOCK(src);
+    GstBufferPool *pool = src->sbs_pool;
+    src->sbs_pool = NULL;
+    GST_OBJECT_UNLOCK(src);
+    if (pool) {
+        gst_buffer_pool_set_active(pool, FALSE);
+        gst_object_unref(pool);
     }
     src->sbs_pool_width = 0;
     src->sbs_pool_height = 0;
@@ -3524,8 +3532,13 @@ static gboolean gst_zedsrc_unlock(GstBaseSrc *bsrc) {
     src->stop_requested = TRUE;
 
 #if defined(SL_ENABLE_ADVANCED_CAPTURE_API) && defined(HAVE_NVBUFSURFTRANSFORM)
-    if (src->sbs_pool) {
-        gst_buffer_pool_set_flushing(src->sbs_pool, TRUE);
+    GST_OBJECT_LOCK(src);
+    GstBufferPool *pool =
+        src->sbs_pool ? GST_BUFFER_POOL(gst_object_ref(src->sbs_pool)) : NULL;
+    GST_OBJECT_UNLOCK(src);
+    if (pool) {
+        gst_buffer_pool_set_flushing(pool, TRUE);
+        gst_object_unref(pool);
     }
 #endif
 
@@ -3540,8 +3553,13 @@ static gboolean gst_zedsrc_unlock_stop(GstBaseSrc *bsrc) {
     src->stop_requested = FALSE;
 
 #if defined(SL_ENABLE_ADVANCED_CAPTURE_API) && defined(HAVE_NVBUFSURFTRANSFORM)
-    if (src->sbs_pool) {
-        gst_buffer_pool_set_flushing(src->sbs_pool, FALSE);
+    GST_OBJECT_LOCK(src);
+    GstBufferPool *pool =
+        src->sbs_pool ? GST_BUFFER_POOL(gst_object_ref(src->sbs_pool)) : NULL;
+    GST_OBJECT_UNLOCK(src);
+    if (pool) {
+        gst_buffer_pool_set_flushing(pool, FALSE);
+        gst_object_unref(pool);
     }
 #endif
 

--- a/gst-zed-src/gstzedsrc.cpp
+++ b/gst-zed-src/gstzedsrc.cpp
@@ -70,127 +70,124 @@ static GstFlowReturn gst_zedsrc_fill(GstPushSrc *src, GstBuffer *buf);
 static GstFlowReturn gst_zedsrc_create(GstPushSrc *src, GstBuffer **buf);
 
 #ifdef HAVE_NVBUFSURFTRANSFORM
+
+// Reuse a bounded set of SBS NVMM destination surfaces. NVJPG registration is
+// address-sensitive, so the source must block on pool exhaustion instead of
+// allocating unbounded distinct surfaces.
+#define GST_ZEDSRC_SBS_POOL_SIZE 4
+
 typedef struct {
-    GstZedSrc *src;
-    NvBufSurface *surf;
-    gint pool_index;
-} StereoSbsWrappedCtx;
+    GstBufferPool parent;
+    NvBufSurfaceCreateParams create_params;
+    gboolean params_valid;
+} GstZedSbsPool;
 
-static void gst_zedsrc_stereo_sbs_release_slot(GstZedSrc *src, gint pool_index) {
-    if (pool_index >= 0 && pool_index < GST_ZEDSRC_STEREO_SBS_POOL_SIZE) {
-        g_atomic_int_set(&src->stereo_sbs_pool_in_use[pool_index], 0);
-    }
+typedef struct {
+    GstBufferPoolClass parent_class;
+} GstZedSbsPoolClass;
+
+static GType gst_zed_sbs_pool_get_type(void);
+#define GST_TYPE_ZED_SBS_POOL (gst_zed_sbs_pool_get_type())
+#define GST_ZED_SBS_POOL(obj)                                                                      \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_ZED_SBS_POOL, GstZedSbsPool))
+
+G_DEFINE_TYPE(GstZedSbsPool, gst_zed_sbs_pool, GST_TYPE_BUFFER_POOL)
+
+static GQuark gst_zed_sbs_surf_quark(void) {
+    return g_quark_from_static_string("zed-sbs-nvbufsurface");
 }
 
-static gboolean gst_zedsrc_stereo_sbs_pool_any_in_use(GstZedSrc *src) {
-    for (gint i = 0; i < GST_ZEDSRC_STEREO_SBS_POOL_SIZE; ++i) {
-        if (g_atomic_int_get(&src->stereo_sbs_pool_in_use[i]) != 0) {
-            return TRUE;
-        }
+static GstFlowReturn gst_zed_sbs_pool_alloc_buffer(GstBufferPool *pool, GstBuffer **buffer,
+                                                   GstBufferPoolAcquireParams *params) {
+    GstZedSbsPool *self = GST_ZED_SBS_POOL(pool);
+    if (!self->params_valid) {
+        return GST_FLOW_ERROR;
     }
-    return FALSE;
+
+    NvBufSurface *surf = NULL;
+    if (NvBufSurfaceCreate(&surf, 1, &self->create_params) != 0 || !surf) {
+        return GST_FLOW_ERROR;
+    }
+
+    GstBuffer *buf = gst_buffer_new_wrapped_full((GstMemoryFlags) 0, surf, sizeof(NvBufSurface), 0,
+                                                 sizeof(NvBufSurface), NULL, NULL);
+    if (!buf) {
+        NvBufSurfaceDestroy(surf);
+        return GST_FLOW_ERROR;
+    }
+    gst_mini_object_set_qdata(GST_MINI_OBJECT(buf), gst_zed_sbs_surf_quark(), surf, NULL);
+    *buffer = buf;
+    return GST_FLOW_OK;
 }
 
-static void gst_zedsrc_stereo_sbs_pool_cleanup(GstZedSrc *src, gboolean force) {
-    for (gint i = 0; i < GST_ZEDSRC_STEREO_SBS_POOL_SIZE; ++i) {
-        if (!force && g_atomic_int_get(&src->stereo_sbs_pool_in_use[i]) != 0) {
-            continue;
-        }
-
-        NvBufSurface *surf = static_cast<NvBufSurface *>(src->stereo_sbs_pool[i]);
-        if (surf) {
-            NvBufSurfaceDestroy(surf);
-            src->stereo_sbs_pool[i] = NULL;
-        }
-
-        if (force) {
-            g_atomic_int_set(&src->stereo_sbs_pool_in_use[i], 0);
-        }
+static void gst_zed_sbs_pool_free_buffer(GstBufferPool *pool, GstBuffer *buffer) {
+    NvBufSurface *surf = static_cast<NvBufSurface *>(
+        gst_mini_object_get_qdata(GST_MINI_OBJECT(buffer), gst_zed_sbs_surf_quark()));
+    if (surf) {
+        NvBufSurfaceDestroy(surf);
     }
-
-    if (force || !gst_zedsrc_stereo_sbs_pool_any_in_use(src)) {
-        src->stereo_sbs_pool_width = 0;
-        src->stereo_sbs_pool_height = 0;
-        src->stereo_sbs_pool_gpu_id = -1;
-        src->stereo_sbs_pool_mem_type = -1;
-        src->stereo_sbs_pool_layout = -1;
-        src->stereo_sbs_pool_color_format = -1;
-    }
+    GST_BUFFER_POOL_CLASS(gst_zed_sbs_pool_parent_class)->free_buffer(pool, buffer);
 }
 
-static NvBufSurface *gst_zedsrc_stereo_sbs_pool_acquire(GstZedSrc *src, guint32 width,
-                                                        guint32 height, gint gpu_id, gint mem_type,
-                                                        gint layout, gint color_format,
-                                                        gint *pool_index) {
-    *pool_index = -1;
-
-    gboolean configured = (src->stereo_sbs_pool_width != 0 && src->stereo_sbs_pool_height != 0);
-    gboolean matches =
-        configured && src->stereo_sbs_pool_width == width &&
-        src->stereo_sbs_pool_height == height && src->stereo_sbs_pool_gpu_id == gpu_id &&
-        src->stereo_sbs_pool_mem_type == mem_type && src->stereo_sbs_pool_layout == layout &&
-        src->stereo_sbs_pool_color_format == color_format;
-
-    if (!matches) {
-        gst_zedsrc_stereo_sbs_pool_cleanup(src, FALSE);
-        if (gst_zedsrc_stereo_sbs_pool_any_in_use(src)) {
-            return NULL;
-        }
-
-        src->stereo_sbs_pool_width = width;
-        src->stereo_sbs_pool_height = height;
-        src->stereo_sbs_pool_gpu_id = gpu_id;
-        src->stereo_sbs_pool_mem_type = mem_type;
-        src->stereo_sbs_pool_layout = layout;
-        src->stereo_sbs_pool_color_format = color_format;
-    }
-
-    for (gint i = 0; i < GST_ZEDSRC_STEREO_SBS_POOL_SIZE; ++i) {
-        if (!g_atomic_int_compare_and_exchange(&src->stereo_sbs_pool_in_use[i], 0, 1)) {
-            continue;
-        }
-
-        NvBufSurface *surf = static_cast<NvBufSurface *>(src->stereo_sbs_pool[i]);
-        if (!surf) {
-            NvBufSurfaceCreateParams create_params = {0};
-            create_params.gpuId = gpu_id;
-            create_params.width = width;
-            create_params.height = height;
-            create_params.size = 0;
-            create_params.isContiguous = true;
-            create_params.colorFormat = static_cast<NvBufSurfaceColorFormat>(color_format);
-            create_params.layout = static_cast<NvBufSurfaceLayout>(layout);
-            create_params.memType = static_cast<NvBufSurfaceMemType>(mem_type);
-
-            if (NvBufSurfaceCreate(&surf, 1, &create_params) != 0 || !surf) {
-                g_atomic_int_set(&src->stereo_sbs_pool_in_use[i], 0);
-                continue;
-            }
-
-            src->stereo_sbs_pool[i] = surf;
-        }
-
-        *pool_index = i;
-        return surf;
-    }
-
-    return NULL;
+static void gst_zed_sbs_pool_class_init(GstZedSbsPoolClass *klass) {
+    GstBufferPoolClass *pool_class = GST_BUFFER_POOL_CLASS(klass);
+    pool_class->alloc_buffer = gst_zed_sbs_pool_alloc_buffer;
+    pool_class->free_buffer = gst_zed_sbs_pool_free_buffer;
 }
 
-static void stereo_sbs_wrapped_buffer_destroy_notify(gpointer data) {
-    StereoSbsWrappedCtx *ctx = static_cast<StereoSbsWrappedCtx *>(data);
-    if (!ctx) {
-        return;
+static void gst_zed_sbs_pool_init(GstZedSbsPool *self) {
+    self->params_valid = FALSE;
+}
+
+static gboolean gst_zedsrc_sbs_pool_ensure(GstZedSrc *src, const NvBufSurfaceCreateParams *cp,
+                                           GstCaps *caps) {
+    if (src->sbs_pool && src->sbs_pool_width == cp->width && src->sbs_pool_height == cp->height &&
+        src->sbs_pool_gpu_id == cp->gpuId && src->sbs_pool_mem_type == (gint) cp->memType &&
+        src->sbs_pool_layout == (gint) cp->layout &&
+        src->sbs_pool_color_format == (gint) cp->colorFormat) {
+        return TRUE;
     }
 
-    if (ctx->pool_index >= 0) {
-        gst_zedsrc_stereo_sbs_release_slot(ctx->src, ctx->pool_index);
-    } else if (ctx->surf) {
-        NvBufSurfaceDestroy(ctx->surf);
+    if (src->sbs_pool) {
+        gst_buffer_pool_set_active(src->sbs_pool, FALSE);
+        gst_object_unref(src->sbs_pool);
+        src->sbs_pool = NULL;
     }
 
-    gst_object_unref(ctx->src);
-    g_free(ctx);
+    GstBufferPool *pool = static_cast<GstBufferPool *>(g_object_new(GST_TYPE_ZED_SBS_POOL, NULL));
+    GST_ZED_SBS_POOL(pool)->create_params = *cp;
+    GST_ZED_SBS_POOL(pool)->params_valid = TRUE;
+
+    GstStructure *config = gst_buffer_pool_get_config(pool);
+    gst_buffer_pool_config_set_params(config, caps, sizeof(NvBufSurface),
+                                      GST_ZEDSRC_SBS_POOL_SIZE, GST_ZEDSRC_SBS_POOL_SIZE);
+    if (!gst_buffer_pool_set_config(pool, config) || !gst_buffer_pool_set_active(pool, TRUE)) {
+        gst_object_unref(pool);
+        return FALSE;
+    }
+
+    src->sbs_pool = pool;
+    src->sbs_pool_width = cp->width;
+    src->sbs_pool_height = cp->height;
+    src->sbs_pool_gpu_id = cp->gpuId;
+    src->sbs_pool_mem_type = (gint) cp->memType;
+    src->sbs_pool_layout = (gint) cp->layout;
+    src->sbs_pool_color_format = (gint) cp->colorFormat;
+    return TRUE;
+}
+
+static void gst_zedsrc_sbs_pool_release(GstZedSrc *src) {
+    if (src->sbs_pool) {
+        gst_buffer_pool_set_active(src->sbs_pool, FALSE);
+        gst_object_unref(src->sbs_pool);
+        src->sbs_pool = NULL;
+    }
+    src->sbs_pool_width = 0;
+    src->sbs_pool_height = 0;
+    src->sbs_pool_gpu_id = -1;
+    src->sbs_pool_mem_type = -1;
+    src->sbs_pool_layout = -1;
+    src->sbs_pool_color_format = -1;
 }
 #endif  // HAVE_NVBUFSURFTRANSFORM
 #endif  // SL_ENABLE_ADVANCED_CAPTURE_API
@@ -1847,7 +1844,7 @@ static void gst_zedsrc_class_init(GstZedSrcClass *klass) {
 
 static void gst_zedsrc_reset(GstZedSrc *src) {
 #if defined(SL_ENABLE_ADVANCED_CAPTURE_API) && defined(HAVE_NVBUFSURFTRANSFORM)
-    gst_zedsrc_stereo_sbs_pool_cleanup(src, FALSE);
+    gst_zedsrc_sbs_pool_release(src);
 #endif
 
     if (src->zed.isOpened()) {
@@ -2002,16 +1999,13 @@ static void gst_zedsrc_init(GstZedSrc *src) {
     src->caps = NULL;
 
 #if defined(SL_ENABLE_ADVANCED_CAPTURE_API) && defined(HAVE_NVBUFSURFTRANSFORM)
-    for (gint i = 0; i < GST_ZEDSRC_STEREO_SBS_POOL_SIZE; ++i) {
-        src->stereo_sbs_pool[i] = NULL;
-        g_atomic_int_set(&src->stereo_sbs_pool_in_use[i], 0);
-    }
-    src->stereo_sbs_pool_width = 0;
-    src->stereo_sbs_pool_height = 0;
-    src->stereo_sbs_pool_gpu_id = -1;
-    src->stereo_sbs_pool_mem_type = -1;
-    src->stereo_sbs_pool_layout = -1;
-    src->stereo_sbs_pool_color_format = -1;
+    src->sbs_pool = NULL;
+    src->sbs_pool_width = 0;
+    src->sbs_pool_height = 0;
+    src->sbs_pool_gpu_id = -1;
+    src->sbs_pool_mem_type = -1;
+    src->sbs_pool_layout = -1;
+    src->sbs_pool_color_format = -1;
 #endif
 
     gst_zedsrc_reset(src);
@@ -2789,7 +2783,7 @@ void gst_zedsrc_finalize(GObject *object) {
 
     /* clean up object here */
 #if defined(SL_ENABLE_ADVANCED_CAPTURE_API) && defined(HAVE_NVBUFSURFTRANSFORM)
-    gst_zedsrc_stereo_sbs_pool_cleanup(src, TRUE);
+    gst_zedsrc_sbs_pool_release(src);
 #endif
 
     if (src->caps) {
@@ -3529,6 +3523,12 @@ static gboolean gst_zedsrc_unlock(GstBaseSrc *bsrc) {
 
     src->stop_requested = TRUE;
 
+#if defined(SL_ENABLE_ADVANCED_CAPTURE_API) && defined(HAVE_NVBUFSURFTRANSFORM)
+    if (src->sbs_pool) {
+        gst_buffer_pool_set_flushing(src->sbs_pool, TRUE);
+    }
+#endif
+
     return TRUE;
 }
 
@@ -3538,6 +3538,12 @@ static gboolean gst_zedsrc_unlock_stop(GstBaseSrc *bsrc) {
     GST_TRACE_OBJECT(src, "gst_zedsrc_unlock_stop");
 
     src->stop_requested = FALSE;
+
+#if defined(SL_ENABLE_ADVANCED_CAPTURE_API) && defined(HAVE_NVBUFSURFTRANSFORM)
+    if (src->sbs_pool) {
+        gst_buffer_pool_set_flushing(src->sbs_pool, FALSE);
+    }
+#endif
 
     return TRUE;
 }
@@ -4304,34 +4310,35 @@ static GstFlowReturn gst_zedsrc_create(GstPushSrc *psrc, GstBuffer **outbuf) {
         GST_DEBUG_OBJECT(src, "Stereo composite: L=%ux%u R=%ux%u -> SbS=%ux%u", params_l->width,
                          params_l->height, params_r->width, params_r->height, stereo_w, single_h);
 
-        // Acquire reusable destination surface from pool (fallback to one-off if pool busy)
-        gint pool_index = -1;
-        NvBufSurface *dst_surf = gst_zedsrc_stereo_sbs_pool_acquire(
-            src, stereo_w, single_h, nvbuf->gpuId, nvbuf->memType, params_l->layout,
-            params_l->colorFormat, &pool_index);
-        gboolean from_pool = (pool_index >= 0 && dst_surf != NULL);
+        NvBufSurfaceCreateParams create_params = {0};
+        create_params.gpuId = nvbuf->gpuId;
+        create_params.width = stereo_w;
+        create_params.height = single_h;
+        create_params.size = 0;
+        create_params.isContiguous = true;
+        create_params.colorFormat = params_l->colorFormat;
+        create_params.layout = params_l->layout;
+        create_params.memType = nvbuf->memType;
 
-        if (!dst_surf) {
-            NvBufSurfaceCreateParams create_params = {0};
-            create_params.gpuId = nvbuf->gpuId;
-            create_params.width = stereo_w;
-            create_params.height = single_h;
-            create_params.size = 0;
-            create_params.isContiguous = true;
-            create_params.colorFormat = params_l->colorFormat;
-            create_params.layout = params_l->layout;
-            create_params.memType = nvbuf->memType;
-
-            if (NvBufSurfaceCreate(&dst_surf, 1, &create_params) != 0 || !dst_surf) {
-                GST_ELEMENT_ERROR(
-                    src, RESOURCE, FAILED,
-                    ("Failed to allocate stereo composite NvBufSurface %ux%u", stereo_w, single_h),
-                    (NULL));
-                delete raw_buffer;
-                cuCtxPopCurrent_v2(NULL);
-                return GST_FLOW_ERROR;
-            }
+        if (!gst_zedsrc_sbs_pool_ensure(src, &create_params, src->caps)) {
+            GST_ELEMENT_ERROR(
+                src, RESOURCE, FAILED,
+                ("Failed to configure stereo SBS buffer pool %ux%u", stereo_w, single_h), (NULL));
+            delete raw_buffer;
+            cuCtxPopCurrent_v2(NULL);
+            return GST_FLOW_ERROR;
         }
+
+        GstBuffer *pooled = NULL;
+        GstFlowReturn acq_ret = gst_buffer_pool_acquire_buffer(src->sbs_pool, &pooled, NULL);
+        if (acq_ret != GST_FLOW_OK) {
+            delete raw_buffer;
+            cuCtxPopCurrent_v2(NULL);
+            return acq_ret;
+        }
+
+        NvBufSurface *dst_surf = static_cast<NvBufSurface *>(
+            gst_mini_object_get_qdata(GST_MINI_OBJECT(pooled), gst_zed_sbs_surf_quark()));
 
         // Composite left+right into destination in one call
         NvBufSurfTransformCompositeParams comp_params;
@@ -4381,11 +4388,7 @@ static GstFlowReturn gst_zedsrc_create(GstPushSrc *psrc, GstBuffer **outbuf) {
         if (comp_ret != 0) {
             GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
                               ("NvBufSurfTransformComposite failed: %d", comp_ret), (NULL));
-            if (from_pool) {
-                gst_zedsrc_stereo_sbs_release_slot(src, pool_index);
-            } else {
-                NvBufSurfaceDestroy(dst_surf);
-            }
+            gst_buffer_unref(pooled);
             delete raw_buffer;
             cuCtxPopCurrent_v2(NULL);
             return GST_FLOW_ERROR;
@@ -4395,27 +4398,7 @@ static GstFlowReturn gst_zedsrc_create(GstPushSrc *psrc, GstBuffer **outbuf) {
         delete raw_buffer;
         raw_buffer = NULL;
 
-        StereoSbsWrappedCtx *stereo_ctx = g_new0(StereoSbsWrappedCtx, 1);
-        stereo_ctx->src = GST_ZED_SRC(gst_object_ref(src));
-        stereo_ctx->surf = dst_surf;
-        stereo_ctx->pool_index = from_pool ? pool_index : -1;
-
-        // Wrap the composited dst_surf into GstBuffer
-        buf = gst_buffer_new_wrapped_full((GstMemoryFlags) 0,
-                                          dst_surf,   // Data pointer is the NvBufSurface*
-                                          sizeof(NvBufSurface),   // Max size
-                                          0,                      // Offset
-                                          sizeof(NvBufSurface),   // Size
-                                          stereo_ctx,             // User data for destroy callback
-                                          stereo_sbs_wrapped_buffer_destroy_notify);
-        if (!buf) {
-            GST_ELEMENT_ERROR(src, RESOURCE, FAILED,
-                              ("Failed to wrap stereo composite NvBufSurface into GstBuffer"),
-                              (NULL));
-            stereo_sbs_wrapped_buffer_destroy_notify(stereo_ctx);
-            cuCtxPopCurrent_v2(NULL);
-            return GST_FLOW_ERROR;
-        }
+        buf = pooled;
         // <---- Stereo side-by-side
 #endif  // HAVE_NVBUFSURFTRANSFORM
     } else if (stream_type == GST_ZEDSRC_RAW_NV12_RIGHT) {

--- a/gst-zed-src/gstzedsrc.h
+++ b/gst-zed-src/gstzedsrc.h
@@ -189,6 +189,7 @@ struct _GstZedSrc {
 
 #if defined(SL_ENABLE_ADVANCED_CAPTURE_API) && defined(HAVE_NVBUFSURFTRANSFORM)
     // Reusable destination-surface pool for NV12 stereo side-by-side composition.
+    // Pointer accesses across threads must hold GST_OBJECT_LOCK.
     GstBufferPool *sbs_pool;
     guint32 sbs_pool_width;
     guint32 sbs_pool_height;

--- a/gst-zed-src/gstzedsrc.h
+++ b/gst-zed-src/gstzedsrc.h
@@ -188,16 +188,14 @@ struct _GstZedSrc {
     gboolean stop_requested;
 
 #if defined(SL_ENABLE_ADVANCED_CAPTURE_API) && defined(HAVE_NVBUFSURFTRANSFORM)
-    // Reusable destination surfaces for NV12 stereo side-by-side composition
-#define GST_ZEDSRC_STEREO_SBS_POOL_SIZE 4
-    gpointer stereo_sbs_pool[GST_ZEDSRC_STEREO_SBS_POOL_SIZE];
-    gint stereo_sbs_pool_in_use[GST_ZEDSRC_STEREO_SBS_POOL_SIZE];
-    guint32 stereo_sbs_pool_width;
-    guint32 stereo_sbs_pool_height;
-    gint stereo_sbs_pool_gpu_id;
-    gint stereo_sbs_pool_mem_type;
-    gint stereo_sbs_pool_layout;
-    gint stereo_sbs_pool_color_format;
+    // Reusable destination-surface pool for NV12 stereo side-by-side composition.
+    GstBufferPool *sbs_pool;
+    guint32 sbs_pool_width;
+    guint32 sbs_pool_height;
+    gint sbs_pool_gpu_id;
+    gint sbs_pool_mem_type;
+    gint sbs_pool_layout;
+    gint sbs_pool_color_format;
 #endif
 };
 

--- a/scripts/jetson/sbs_pool_fault_repro.sh
+++ b/scripts/jetson/sbs_pool_fault_repro.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# =============================================================================
+# Minimal NV12 SBS / nvjpegenc surface registration fault reproducer
+# =============================================================================
+#
+# Invariant:
+#   stream-type=7 must keep the number of distinct SBS NVMM destination surfaces
+#   bounded while downstream holds buffers. Under backpressure it may slow down
+#   or block, but it must not make NVJPG print "Surface not registered".
+#
+# This script intentionally applies encoder-side backpressure and scans stderr
+# for the NVIDIA NVJPG failure signature.
+#
+# Usage:
+#   ./sbs_pool_fault_repro.sh [timeout_seconds]
+#
+# Exit codes:
+#   0 - NVJPG surface registration fault reproduced
+#   1 - Signature not observed before timeout
+#   2 - Prerequisites not met
+# =============================================================================
+
+set -u
+set -o pipefail
+
+TIMEOUT_SECONDS="${1:-300}"
+SCRIPT_NAME="$(basename "$0")"
+LOG_FILE="/tmp/zed_sbs_pool_fault_repro_$$.log"
+
+CAMERA_RESOLUTION=2
+CAMERA_FPS=60
+WIDTH=3840
+HEIGHT=1200
+QUEUE_BUFFERS=60
+HOLD_US=40000
+
+cleanup() {
+    rm -f "$LOG_FILE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+usage() {
+    echo "Usage: $SCRIPT_NAME [timeout_seconds]"
+}
+
+if [ "$#" -gt 1 ]; then
+    usage
+    exit 2
+fi
+
+case "$TIMEOUT_SECONDS" in
+    ''|*[!0-9]*)
+        echo "ERROR: timeout_seconds must be a positive integer"
+        exit 2
+        ;;
+esac
+
+if [ "$TIMEOUT_SECONDS" -le 0 ]; then
+    echo "ERROR: timeout_seconds must be > 0"
+    exit 2
+fi
+
+if ! command -v gst-launch-1.0 >/dev/null 2>&1; then
+    echo "ERROR: gst-launch-1.0 not found"
+    exit 2
+fi
+
+if ! gst-inspect-1.0 zedsrc >/dev/null 2>&1; then
+    echo "ERROR: zedsrc plugin not found"
+    exit 2
+fi
+
+if ! gst-inspect-1.0 nvjpegenc >/dev/null 2>&1; then
+    echo "ERROR: nvjpegenc not found"
+    exit 2
+fi
+
+ZEDSRC_INSPECT="$(gst-inspect-1.0 zedsrc 2>/dev/null)"
+if ! printf '%s\n' "$ZEDSRC_INSPECT" | grep -q "Raw NV12 stereo"; then
+    echo "ERROR: zedsrc does not advertise stream-type=7 NV12 stereo support"
+    exit 2
+fi
+
+echo "=============================================="
+echo " ZED SBS NVMM / nvjpegenc fault reproducer"
+echo "=============================================="
+echo " Timeout:       ${TIMEOUT_SECONDS}s"
+echo " Camera:        resolution=${CAMERA_RESOLUTION}, fps=${CAMERA_FPS}"
+echo " Output caps:   NV12 ${WIDTH}x${HEIGHT} memory:NVMM"
+echo " Backpressure:  queue=${QUEUE_BUFFERS}, identity sleep=${HOLD_US}us"
+echo " Looking for:   Surface not registered"
+echo "=============================================="
+echo ""
+
+timeout "${TIMEOUT_SECONDS}s" \
+    gst-launch-1.0 -e \
+        zedsrc stream-type=7 camera-resolution="${CAMERA_RESOLUTION}" camera-fps="${CAMERA_FPS}" \
+            enable-positional-tracking=false depth-mode=0 ! \
+        "video/x-raw(memory:NVMM),format=NV12,width=${WIDTH},height=${HEIGHT}" ! \
+        queue max-size-buffers="${QUEUE_BUFFERS}" max-size-bytes=0 max-size-time=0 ! \
+        identity sleep-time="${HOLD_US}" ! \
+        nvjpegenc ! \
+        fakesink sync=false \
+    2>&1 | tee "$LOG_FILE"
+
+GST_STATUS=${PIPESTATUS[0]}
+
+echo ""
+echo "=============================================="
+echo " Verdict"
+echo "=============================================="
+
+if grep -q \
+    -e "Surface not registered" \
+    -e "NVJPGGetSurfPinHandle" \
+    -e "NVJPGPushSurfFalconMethodRelocShift" \
+    -e "JPEGEncFeedFrame" \
+    "$LOG_FILE"; then
+    echo "REPRODUCED: NVJPG surface registration fault was printed."
+    exit 0
+fi
+
+if [ "$GST_STATUS" -eq 124 ]; then
+    echo "NOT reproduced: no NVJPG signature before timeout."
+else
+    echo "NOT reproduced: pipeline exited without the target NVJPG signature."
+    echo "gst-launch exit status: $GST_STATUS"
+fi
+
+exit 1


### PR DESCRIPTION
## Summary
- Add a minimal Jetson repro script for the NV12 stereo SBS -> nvjpegenc surface registration fault
- Replace the ad hoc SBS destination-surface reuse path with a bounded GstBufferPool
- Block when the SBS destination pool is exhausted instead of allocating additional distinct NVMM surfaces

## Rationale
This follows GStreamer's normal buffer/pool ownership model. A `GstBuffer` pushed downstream may stay referenced after `create()` returns, so the memory backing that buffer must remain valid until the final buffer reference is released. For a finite source-side pool, exhaustion should therefore block, drop, or return a flow/error condition rather than allocate unbounded new surfaces or invalidate memory that may still be referenced downstream.

`GstBufferPool` provides that behavior directly: buffers acquired from the pool are returned when their final reference is released, and the default acquire path blocks when the pool is empty unless `DONTWAIT` is requested.

References:
- https://gstreamer.freedesktop.org/documentation/plugin-development/advanced/allocation.html
- https://gstreamer.freedesktop.org/documentation/gstreamer/gstbuffer.html
- https://gstreamer.freedesktop.org/documentation/gstreamer/gstbufferpool.html

## Validation
- Before the fix, the repro script immediately printed NVJPG "Surface not registered" errors on a ZEDBOX
- After rebuilding the patched plugin on the same ZEDBOX, the repro script did not reproduce the NVJPG signature in 4 runs of 60 seconds each
- Built and installed successfully with the existing CMake flow on Jetson / ZED SDK 5.2.3